### PR TITLE
Update urbackup-server to 2.5.35, change hardcoded usernames in helper tools to sc-urbackup

### DIFF
--- a/cross/urbackup-server/Makefile
+++ b/cross/urbackup-server/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = urbackup-server
-PKG_VERS = 2.5.32
+PKG_VERS = 2.5.35
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = https://hndl.urbackup.org/Server/$(PKG_VERS)

--- a/cross/urbackup-server/digests
+++ b/cross/urbackup-server/digests
@@ -13,3 +13,6 @@ urbackup-server-2.5.30.tar.gz MD5 c490ad8b4f9c40a77be0ec74c30605c9
 urbackup-server-2.5.32.tar.gz SHA1 bf40977e53182ead392593ac7fbd2674a365174b
 urbackup-server-2.5.32.tar.gz SHA256 ff9be7c04f616010d165cea5035b0cbc9f3956c4b102a4192f6d9d4ace8516ff
 urbackup-server-2.5.32.tar.gz MD5 29cce2bafa2703df520224ec7e36223a
+urbackup-server-2.5.35.tar.gz SHA1 5412cc2f0353d322463a80ccc369f300d3ba7d8d
+urbackup-server-2.5.35.tar.gz SHA256 3505796b622e9e34c3093585d295eb850114d85d5ea69ecaa8b0f8939ed3a1b9
+urbackup-server-2.5.35.tar.gz MD5 e5fba2fd90015c3770ade1bdaaeb66de

--- a/cross/urbackup-server/patches/001-snapshot-helper-user.patch
+++ b/cross/urbackup-server/patches/001-snapshot-helper-user.patch
@@ -1,0 +1,11 @@
+--- snapshot_helper/main.cpp.orig	2023-12-13 09:09:04.975137594 +0000
++++ snapshot_helper/main.cpp	2023-12-13 09:09:25.139460054 +0000
+@@ -242,7 +242,7 @@
+ 
+ bool chown_dir(const std::string& dir)
+ {
+-	passwd* user_info = getpwnam("urbackup");
++	passwd* user_info = getpwnam("sc-urbackup");
+ 	if(user_info)
+ 	{
+ 		int rc = chown(dir.c_str(), user_info->pw_uid, user_info->pw_gid);

--- a/cross/urbackup-server/patches/002-mount-helper-user.patch
+++ b/cross/urbackup-server/patches/002-mount-helper-user.patch
@@ -1,0 +1,29 @@
+--- mount_helper/main.cpp.orig	2023-12-13 09:28:17.437391497 +0000
++++ mount_helper/main.cpp	2023-12-13 09:29:09.155652064 +0000
+@@ -249,7 +249,7 @@
+ 
+ bool chown_dir(const std::string& dir)
+ {
+-	passwd* user_info = getpwnam("urbackup");
++	passwd* user_info = getpwnam("sc-urbackup");
+ 	if(user_info)
+ 	{
+ 		int rc = chown(dir.c_str(), user_info->pw_uid, user_info->pw_gid);
+@@ -426,7 +426,7 @@
+ 	chown_dir(mountpoint);
+ 	chown_dir("/dev/loop"+convert(devnum));
+ 	
+-	passwd* user_info = getpwnam("urbackup");
++	passwd* user_info = getpwnam("sc-urbackup");
+ 	std::string uid = "uid=0";
+ 	std::string gid = "gid=0";
+ 	if(user_info)
+@@ -618,7 +618,7 @@
+ 		chown_dir(devpoint);
+ 		
+ 		std::string mount_options="";
+-		passwd* user_info = getpwnam("urbackup");
++		passwd* user_info = getpwnam("sc-urbackup");
+ 		if(user_info)
+ 		{
+ 			mount_options+="uid="+convert(user_info->pw_uid)+",gid="+convert(user_info->pw_gid)+",allow_root";

--- a/spk/urbackup/Makefile
+++ b/spk/urbackup/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = urbackup
 SPK_VERS = 2.5.35
-SPK_REV = 1
+SPK_REV = 2
 SPK_ICON = src/urbackup.png
 DSM_UI_DIR = app
 

--- a/spk/urbackup/Makefile
+++ b/spk/urbackup/Makefile
@@ -1,5 +1,5 @@
 SPK_NAME = urbackup
-SPK_VERS = 2.5.32
+SPK_VERS = 2.5.35
 SPK_REV = 1
 SPK_ICON = src/urbackup.png
 DSM_UI_DIR = app

--- a/spk/urbackup/src/service-setup.sh
+++ b/spk/urbackup/src/service-setup.sh
@@ -14,8 +14,14 @@ SVC_WRITE_PID=y
 service_postinst ()
 {
    	mkdir -p ${SYNOPKG_PKGVAR}/urbackup
-    echo "${SYNOPKG_PKGHOME}" > ${SYNOPKG_PKGVAR}/urbackup/backupfolder 
+    echo "${SYNOPKG_PKGHOME}" > ${SYNOPKG_PKGVAR}/urbackup/backupfolder
+    mkdir -p -m 0755 /etc/urbackup
+    echo "${SYNOPKG_PKGHOME}" > /etc/urbackup/backupfolder
     sed -i 's/package/root/g' /var/packages/urbackup/conf/privilege
+    chown root "${SYNOPKG_PKGDEST}/bin/urbackup_snapshot_helper"
+    chown root "${SYNOPKG_PKGDEST}/bin/urbackup_mount_helper"
+    chmod +s "${SYNOPKG_PKGDEST}/bin/urbackup_snapshot_helper"
+    chmod +s "${SYNOPKG_PKGDEST}/bin/urbackup_mount_helper"
 }
 
 service_prestart ()


### PR DESCRIPTION
## Description

- Update urbackup-server to 2.5.35
- Change hardcoded usernames in helper tools from `urbackup` to `sc-urbackup` to allow the snapshot_helper and mount_helper tools to work on Synology correctly

## Checklist

- [ ] Build rule `all-supported` completed successfully - *generic x64 target didn't build, but that's using an ancient compiler*
- [ ] New installation of package completed successfully - *UNABLE TO TEST (I only have one NAS)*
- [x] Package upgrade completed successfully (Manually install the package again) - *Worked*
- [x] Package [functionality was tested](https://github.com/SynoCommunity/spksrc/wiki/Package-Update-Policy#tests-checks) - Worked after upgrade
- [ ] Any needed [documentation](https://github.com/SynoCommunity/spksrc/wiki/Create-documentation) is updated/created - *N/A*


### Type of change

<!--Please use any relevant tags.-->
- [x] Bug fix
- [ ] New Package
- [x] Package update
- [ ] Includes small framework changes
- [ ] This change requires a documentation update (e.g. Wiki)
